### PR TITLE
Updated link to point to GitHub wiki

### DIFF
--- a/Builds/build/README.txt
+++ b/Builds/build/README.txt
@@ -1,1 +1,1 @@
-Have a look at http://code.google.com/p/bimserver/wiki/Download for help choosing the right file
+Have a look at https://github.com/opensourceBIM/BIMserver/wiki/Download for help choosing the right file


### PR DESCRIPTION
The link in the file points to a page that just asks the user to click on a link to the equivalent page in the GitHub wiki. I have updated the file to point directly to the new location.
