### PR TITLE
Fixes #140

### DIFF
--- a/Mergers/src/org/bimserver/merging/AbstractModelMerger.java
+++ b/Mergers/src/org/bimserver/merging/AbstractModelMerger.java
@@ -96,7 +96,6 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 
 public abstract class AbstractModelMerger implements ModelMerger {
-	// TODO: Actually we should not modify the original objects and then copy them to the destination model, but the other way around...
 	protected IfcModelInterface mergeScales(Project project, Set<IfcModelInterface> ifcModels, ModelHelper modelHelper) throws MergeException {
 		long size = 0;
 		for (IfcModelInterface ifcModel : ifcModels) {
@@ -131,9 +130,16 @@ public abstract class AbstractModelMerger implements ModelMerger {
 				float scale = (float) (getLengthUnitPrefix(ifcModel) / Math.pow(10.0, prefix.getValue()));
 				setLengthUnitMeasure(ifcModel, prefix);
 				ifcModel.indexGuids();
-				if (scale != 1.0f) {
-					for (long key : ifcModel.keySet()) {
-						IdEObject idEObject = (IdEObject) ifcModel.get(key);
+
+				for (long key : ifcModel.keySet()) {
+					IdEObject idEObject;
+					try {
+						idEObject = modelHelper.copy((IdEObject) ifcModel.get(key));
+					} catch (IfcModelInterfaceException e) {
+						throw new MergeException(e);
+					}
+					
+					if (idEObject != null && scale != 1.0f) {
 						if (idEObject instanceof IfcAsymmetricIShapeProfileDef) {
 							setIfcAsymmetricIShapeProfileDef(idEObject, scale);
 						} else if (idEObject instanceof IfcBlock) {
@@ -278,14 +284,9 @@ public abstract class AbstractModelMerger implements ModelMerger {
 							setIfcZShapeProfileDef(idEObject, scale);
 						}
 						setDoubleAsStringValues(idEObject);
+						
 					}
-				}
-				for (long key : ifcModel.keySet()) {
-					try {
-						modelHelper.copy((IdEObject) ifcModel.get(key));
-					} catch (IfcModelInterfaceException e) {
-						throw new MergeException(e);
-					}
+					
 				}
 			}
 		}


### PR DESCRIPTION
Also removes one TODO:

```
// TODO: Actually we should not modify the original objects and then copy them to the destination model, but the other way around...
```
