### PR TITLE
Fix Model.get when loadedDeep==true

### DIFF
--- a/BimServer/www/js/bimserverapi_Model.js
+++ b/BimServer/www/js/bimserverapi_Model.js
@@ -127,7 +127,7 @@ define(["bimserverapi_Synchronizer", "bimserverapi_BimServerApiPromise"], functi
 		};
 
 		this.waitForLoaded = function(callback) {
-			if (othis.loaded) {
+			if (othis.loaded || othis.loadedDeep) {
 				callback();
 			} else {
 				othis.waiters.push(callback);


### PR DESCRIPTION
Model.get doesn't work when model is loaded with deep=true.
This fixed it for me.