### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/BimServer/src/org/bimserver/BimServer.java
+++ b/BimServer/src/org/bimserver/BimServer.java
@@ -297,7 +297,7 @@ public class BimServer {
 						DatabaseSession session = bimDatabase.createSession();
 						try {
 							Map<Long, PluginDescriptor> pluginsFound = session.query(pluginCondition, PluginDescriptor.class, OldQuery.getDefault());
-							if (pluginsFound.size() == 0) {
+							if (pluginsFound.isEmpty()) {
 								LOGGER.error("Error changing plugin-state in database, plugin " + pluginContext.getPlugin().getClass().getName() + " not found");
 							} else if (pluginsFound.size() == 1) {
 								PluginDescriptor pluginConfiguration = pluginsFound.values().iterator().next();
@@ -375,7 +375,7 @@ public class BimServer {
 						DatabaseSession session = bimDatabase.createSession();
 						try {
 							Map<Long, PluginDescriptor> pluginsFound = session.query(pluginCondition, PluginDescriptor.class, OldQuery.getDefault());
-							if (pluginsFound.size() == 0) {
+							if (pluginsFound.isEmpty()) {
 								LOGGER.error("Error removing plugin-state in database, plugin " + pluginContext.getPlugin().getClass().getName() + " not found");
 							} else if (pluginsFound.size() == 1) {
 								PluginDescriptor pluginDescriptor = pluginsFound.values().iterator().next();
@@ -911,7 +911,7 @@ public class BimServer {
 			Plugin plugin = pluginContext.getPlugin();
 			Condition pluginCondition = new AttributeCondition(StorePackage.eINSTANCE.getPluginDescriptor_Identifier(), new StringLiteral(pluginContext.getIdentifier()));
 			Map<Long, PluginDescriptor> results = session.query(pluginCondition, PluginDescriptor.class, OldQuery.getDefault());
-			if (results.size() == 0) {
+			if (results.isEmpty()) {
 				PluginDescriptor pluginDescriptor = session.create(PluginDescriptor.class);
 				pluginDescriptor.setIdentifier(pluginContext.getIdentifier());
 				pluginDescriptor.setPluginClassName(plugin.getClass().getName());

--- a/BimServer/src/org/bimserver/GeometryGenerator.java
+++ b/BimServer/src/org/bimserver/GeometryGenerator.java
@@ -178,7 +178,7 @@ public class GeometryGenerator {
 					}
 					for (IdEObject ifcProduct : allWithSubTypes) {
 						IdEObject representation = (IdEObject) ifcProduct.eGet(representationFeature);
-						if (representation != null && ((List<?>) representation.eGet(representationsFeature)).size() > 0) {
+						if (representation != null && ((List<?>) !representation.eGet(representationsFeature)).isEmpty()) {
 							List<?> representations = (List<?>) representation.eGet(representationsFeature);
 							try {
 								RenderEngineInstance renderEngineInstance = renderEngineModel.getInstanceFromExpressId(ifcProduct.getExpressId());
@@ -395,12 +395,12 @@ public class GeometryGenerator {
 				Set<EClass> classes = new HashSet<>();
 				for (IdEObject object : model.getAllWithSubTypes(packageMetaData.getEClass("IfcProduct"))) {
 					IdEObject representation = (IdEObject)object.eGet(representationFeature);
-					if (representation != null && ((List<?>)representation.eGet(representationsFeature)).size() > 0) {
+					if (representation != null && ((List<?>) !representation.eGet(representationsFeature)).isEmpty()) {
 						classes.add(object.eClass());
 					}
 				}
 				
-				if (classes.size() == 0) {
+				if (classes.isEmpty()) {
 					return null;
 				}
 				

--- a/BimServer/src/org/bimserver/database/DatabaseSession.java
+++ b/BimServer/src/org/bimserver/database/DatabaseSession.java
@@ -1543,7 +1543,7 @@ public class DatabaseSession implements LazyLoader, OidProvider, DatabaseInterfa
 	public <T extends IdEObject> T querySingle(Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
 		checkOpen();
 		Collection<T> values = query(condition, clazz, query).values();
-		if (values.size() == 0) {
+		if (values.isEmpty()) {
 			return null;
 		}
 		return values.iterator().next();
@@ -2021,7 +2021,7 @@ public class DatabaseSession implements LazyLoader, OidProvider, DatabaseInterfa
 	public <T extends IdEObject> T getSingle(EClass eClass, QueryInterface query) throws BimserverDatabaseException {
 		IfcModelInterface model = createModel(query);
 		List<T> all = getAllOfType(model, eClass, query).getAll((Class<T>) eClass.getInstanceClass());
-		if (all.size() > 0) {
+		if (!all.isEmpty()) {
 			return all.get(0);
 		}
 		return null;

--- a/BimServer/src/org/bimserver/database/actions/DownloadDatabaseAction.java
+++ b/BimServer/src/org/bimserver/database/actions/DownloadDatabaseAction.java
@@ -86,7 +86,7 @@ public class DownloadDatabaseAction extends AbstractDownloadDatabaseAction<IfcMo
 		IfcModelSet ifcModelSet = new IfcModelSet();
 		long incrSize = 0;
 		EList<ConcreteRevision> concreteRevisions = revision.getConcreteRevisions();
-		if (concreteRevisions.size() == 0) {
+		if (concreteRevisions.isEmpty()) {
 			throw new ServerException("No concrete revisions in revision");
 		}
 		for (ConcreteRevision subRevision : concreteRevisions) {

--- a/BimServer/src/org/bimserver/database/berkeley/BerkeleyKeyValueStore.java
+++ b/BimServer/src/org/bimserver/database/berkeley/BerkeleyKeyValueStore.java
@@ -81,7 +81,7 @@ public class BerkeleyKeyValueStore implements KeyValueStore {
 	public BerkeleyKeyValueStore(Path dataDir) throws DatabaseInitException {
 		if (Files.isDirectory(dataDir)) {
 			try {
-				if (PathUtils.list(dataDir).size() > 0) {
+				if (!PathUtils.list(dataDir).isEmpty()) {
 					LOGGER.info("Non-empty database directory found \"" + dataDir.toString() + "\"");
 					isNew = false;
 				} else {

--- a/BimServer/src/org/bimserver/database/migrations/Schema.java
+++ b/BimServer/src/org/bimserver/database/migrations/Schema.java
@@ -138,7 +138,7 @@ public class Schema {
 
 	public EEnumLiteral createEEnumLiteral(EEnum eEnum, String name) {
 		EEnumLiteral eEnumLiteral = EcoreFactory.eINSTANCE.createEEnumLiteral();
-		if (eEnum.getELiterals().size() == 0) {
+		if (eEnum.getELiterals().isEmpty()) {
 			eEnumLiteral.setValue(0);
 		} else {
 			int largestValue = Integer.MIN_VALUE;

--- a/BimServer/src/org/bimserver/database/queries/QueryPartStackFrame.java
+++ b/BimServer/src/org/bimserver/database/queries/QueryPartStackFrame.java
@@ -49,7 +49,7 @@ public class QueryPartStackFrame extends StackFrame {
 		if (partialQuery.hasOids()) {
 			Set<Long> oidsList = partialQuery.getOids();
 			this.oids = new HashMap<EClass, List<Long>>();
-			if (oidsList.size() == 0) {
+			if (oidsList.isEmpty()) {
 				throw new QueryException("\"oids\" parameter of type array is of size 0");
 			}
 			Iterator<Long> iterator = oidsList.iterator();

--- a/BimServer/src/org/bimserver/database/queries/StartFrame.java
+++ b/BimServer/src/org/bimserver/database/queries/StartFrame.java
@@ -30,7 +30,7 @@ public class StartFrame extends StackFrame {
 
 	public StartFrame(QueryObjectProvider queryObjectProvider, Set<Long> roids) throws QueryException {
 		this.queryObjectProvider = queryObjectProvider;
-		if (roids.size() == 0) {
+		if (roids.isEmpty()) {
 			throw new QueryException("At least one roid required");
 		}
 		this.roidsIterator = roids.iterator();

--- a/BimServer/src/org/bimserver/longaction/LongDownloadAction.java
+++ b/BimServer/src/org/bimserver/longaction/LongDownloadAction.java
@@ -71,7 +71,7 @@ public class LongDownloadAction extends LongDownloadOrCheckoutAction implements 
 			if (session != null) {
 				session.close();
 			}
-			if (getErrors().size() == 0) {
+			if (getErrors().isEmpty()) {
 				changeActionState(ActionState.STARTED, "Done preparing", 0);
 			}
 		}

--- a/BimServer/src/org/bimserver/schemaconverter/Express2EMF.java
+++ b/BimServer/src/org/bimserver/schemaconverter/Express2EMF.java
@@ -720,9 +720,9 @@ public class Express2EMF {
 		Iterator<EntityDefinition> entIter = schema.getEntities().iterator();
 		while (entIter.hasNext()) {
 			EntityDefinition ent = entIter.next();
-			if (ent.getSupertypes().size() > 0) {
+			if (!ent.getSupertypes().isEmpty()) {
 				EClass cls = getOrCreateEClass(ent.getName());
-				if (ent.getSupertypes().size() > 0) {
+				if (!ent.getSupertypes().isEmpty()) {
 					EClass parent = getOrCreateEClass(ent.getSupertypes().get(0).getName());
 					if (!directSubTypes.containsKey(parent)) {
 						directSubTypes.put(parent, new HashSet<EClass>());

--- a/BimServer/src/org/bimserver/servlets/GenericWebServiceServlet.java
+++ b/BimServer/src/org/bimserver/servlets/GenericWebServiceServlet.java
@@ -192,7 +192,7 @@ public class GenericWebServiceServlet extends SubServlet {
 			String[] pathValues = values.split(" ");
 			for (String value : pathValues) {
 				String theValue = value.trim();
-				if (theValue.length() > 0) {
+				if (!theValue.isEmpty()) {
 					list.add(theValue);
 				}
 			}

--- a/BimServer/src/org/bimserver/servlets/SyndicationServlet.java
+++ b/BimServer/src/org/bimserver/servlets/SyndicationServlet.java
@@ -141,7 +141,7 @@ public class SyndicationServlet extends SubServlet {
 				entry.setDescription(description);
 				entries.add(entry);
 			}
-			if (allProjects.size() == 0) {
+			if (allProjects.isEmpty()) {
 				SyndEntry entry = new SyndEntryImpl();
 				entry.setTitle("No projects found");
 				entry.setLink(request.getContextPath() + "/main.jsp");

--- a/BimServer/src/org/bimserver/webservices/impl/PluginServiceImpl.java
+++ b/BimServer/src/org/bimserver/webservices/impl/PluginServiceImpl.java
@@ -1025,7 +1025,7 @@ public class PluginServiceImpl extends GenericServiceImpl implements PluginInter
 
 			Set<Schema> schemaOr = new HashSet<>();
 			
-			if (uniqueSchemas.size() == 0) {
+			if (uniqueSchemas.isEmpty()) {
 				// Wierd, no schemas
 			} else if (uniqueSchemas.size() == 1) {
 				// Easy, just add it, and see if there are converter targets and add those too

--- a/PluginBase/src/org/bimserver/emf/SharedJsonSerializer.java
+++ b/PluginBase/src/org/bimserver/emf/SharedJsonSerializer.java
@@ -286,7 +286,7 @@ public class SharedJsonSerializer implements StreamingReader {
 	}
 	
 	public static Writer quote(String string, Writer w) throws IOException {
-        if (string == null || string.length() == 0) {
+        if (string == null || string.isEmpty()) {
             w.write("\"\"");
             return w;
         }

--- a/PluginBase/src/org/bimserver/emf/SharedJsonStreamingSerializer.java
+++ b/PluginBase/src/org/bimserver/emf/SharedJsonStreamingSerializer.java
@@ -284,7 +284,7 @@ public class SharedJsonStreamingSerializer implements StreamingReader {
 	}
 	
 	public static Writer quote(String string, Writer w) throws IOException {
-        if (string == null || string.length() == 0) {
+        if (string == null || string.isEmpty()) {
             w.write("\"\"");
             return w;
         }

--- a/Shared/src/org/bimserver/ifc/IfcModel.java
+++ b/Shared/src/org/bimserver/ifc/IfcModel.java
@@ -463,7 +463,7 @@ public abstract class IfcModel implements IfcModelInterface {
 			Object referencedObject = idEObject.eGet(eReference);
 			if (eReference.isMany()) {
 				List list = (List) referencedObject;
-				if (list.size() > 0) {
+				if (!list.isEmpty()) {
 					printIndention(indention + 1);
 					System.out.println(eReference.getName() + ": ");
 					for (Object o : list) {

--- a/Shared/src/org/bimserver/ifc/ReferenceCounter.java
+++ b/Shared/src/org/bimserver/ifc/ReferenceCounter.java
@@ -180,7 +180,7 @@ public class ReferenceCounter {
 				for (Object o : list) {
 					IdEObject refObject = (IdEObject) o;
 					references.get(refObject).remove(idEObject);
-					if (references.get(refObject).size() == 0) {
+					if (references.get(refObject).isEmpty()) {
 						totalRemoved += removeInternal(refObject);
 					}
 				}
@@ -188,7 +188,7 @@ public class ReferenceCounter {
 				IdEObject refObject = (IdEObject) idEObject.eGet(eReference);
 				if (references.containsKey(refObject)) {
 					references.get(refObject).remove(idEObject);
-					if (references.get(refObject).size() == 0) {
+					if (references.get(refObject).isEmpty()) {
 						totalRemoved += removeInternal(refObject);
 					}
 				}

--- a/Shared/src/org/bimserver/ifc/printer/IfcPrinter.java
+++ b/Shared/src/org/bimserver/ifc/printer/IfcPrinter.java
@@ -38,7 +38,7 @@ public class IfcPrinter {
 				System.out.println("\t" + reference.getName() + "(" + reference.getEReferenceType().getName() + "): ");
 				if (object.eGet(reference) instanceof EObjectResolvingEList) {
 					EObjectResolvingEList<EObject> referencedObjectList = (EObjectResolvingEList<EObject>)object.eGet(reference);
-					if (referencedObjectList != null && referencedObjectList.size() > 0) {
+					if (referencedObjectList != null && !referencedObjectList.isEmpty()) {
 						if (reference.getEReferenceType().getEStructuralFeature("wrappedValue") != null) {
 							for (Object obj : referencedObjectList) {
 								Object wrappedValue = ((EObject)obj).eGet(reference.getEReferenceType().getEStructuralFeature("wrappedValue"));

--- a/Shared/src/org/bimserver/plugins/PluginManager.java
+++ b/Shared/src/org/bimserver/plugins/PluginManager.java
@@ -796,7 +796,7 @@ public class PluginManager implements PluginManagerInterface {
 
 	public DeserializerPlugin requireDeserializer(String extension) throws DeserializeException {
 		Collection<DeserializerPlugin> allDeserializerPlugins = getAllDeserializerPlugins(extension, true);
-		if (allDeserializerPlugins.size() == 0) {
+		if (allDeserializerPlugins.isEmpty()) {
 			throw new DeserializeException("No deserializers found for type '" + extension + "'");
 		} else {
 			return allDeserializerPlugins.iterator().next();
@@ -880,7 +880,7 @@ public class PluginManager implements PluginManagerInterface {
 				iterator.remove();
 			}
 		}
-		if (allDeserializerPlugins.size() == 0) {
+		if (allDeserializerPlugins.isEmpty()) {
 			throw new PluginException("No deserializers with extension " + extension + " found");
 		}
 		return allDeserializerPlugins.iterator().next();

--- a/Shared/src/org/bimserver/plugins/VirtualFile.java
+++ b/Shared/src/org/bimserver/plugins/VirtualFile.java
@@ -194,7 +194,7 @@ public class VirtualFile implements JavaFileObject {
 	}
 
 	public boolean isDirectory() {
-		return files.size() != 0;
+		return !files.isEmpty();
 	}
 
 	public String getName() {

--- a/Shared/src/org/bimserver/shared/json/JsonConverter.java
+++ b/Shared/src/org/bimserver/shared/json/JsonConverter.java
@@ -165,7 +165,7 @@ public class JsonConverter {
 					}
 					return newObject;
 				} else {
-					if (jsonObject.entrySet().size() != 0) {
+					if (!jsonObject.entrySet().isEmpty()) {
 						throw new ConvertException("Missing __type field in " + jsonObject.toString());
 					} else {
 						return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat