### PR TITLE
Fixing bug in setup page, adding missing comma in js

### DIFF
--- a/BimServer/www/setup.html
+++ b/BimServer/www/setup.html
@@ -375,7 +375,7 @@ function Setup(cd, address) {
 		
 		var pluginsToInstall = {
 			ifcplugins: {repository: "http://central.maven.org/maven2", groupId: "org.opensourcebim", artifactId: "ifcplugins"},
-			binaryserializers: {repository: "http://central.maven.org/maven2", groupId: "org.opensourcebim", artifactId: "binaryserializers"}
+			binaryserializers: {repository: "http://central.maven.org/maven2", groupId: "org.opensourcebim", artifactId: "binaryserializers"},
 			console: {repository: "http://central.maven.org/maven2", groupId: "org.opensourcebim", artifactId: "console"}
 		};
 		cd.find(".plugins input[type=\"checkbox\"]:checked").each(function(index, checkbox){


### PR DESCRIPTION
When I did some tests with the new dev release 1.5 I found this small bug; please pull to master