### PR TITLE
generate geometry for some new IFC4 representation entity types

### DIFF
--- a/BimServer/src/org/bimserver/database/queries/json/ifc4stdlib.json
+++ b/BimServer/src/org/bimserver/database/queries/json/ifc4stdlib.json
@@ -385,6 +385,10 @@
       "IfcOffsetCurve3D": {
          "type": "IfcOffsetCurve3D"
       },
+      "IfcIndexedPolyCurve":{
+         "type": "IfcIndexedPolyCurve",
+         "fields": ["Points", "Segments"]
+      },
       "IfcElementarySurface": {
          "type": "IfcElementarySurface"
       },
@@ -490,6 +494,8 @@
             "IfcPolygonalBoundedHalfSpace",
             "IfcBooleanResult",
             "IfcExtrudedAreaSolid",
+            "IfcTriangulatedFaceSet",
+            "IfcPolygonalFaceSet",
             "IfcBoundingBox",
             "IfcShellBasedSurfaceModel",
             "IfcTextLiteralWithExtent",
@@ -522,6 +528,8 @@
             "IfcPolygonalBoundedHalfSpace",
             "IfcBooleanResult",
             "IfcExtrudedAreaSolid",
+            "IfcTriangulatedFaceSet",
+            "IfcPolygonalFaceSet",
             "IfcBoundingBox",
             "IfcShellBasedSurfaceModel",
             "IfcTextLiteralWithExtent",
@@ -616,7 +624,8 @@
             "IfcEllipse",
             "IfcLine",
             "IfcOffsetCurve2D",
-            "IfcOffsetCurve3D"
+            "IfcOffsetCurve3D",
+            "IfcIndexedPolyCurve"
          ]
       },
       "IfcArbitraryProfileDefWithVoids": {
@@ -685,6 +694,14 @@
             "IfcArbitraryProfileDefWithVoids",
             "IfcParameterizedProfileDef"
          ]
+      },
+     "IfcTriangulatedFaceSet":{
+        "type": "IfcTriangulatedFaceSet",
+        "field": "Coordinates"
+     },
+      "IfcPolygonalFaceSet":{
+         "type": "IfcPolygonalFaceSet",
+         "fields": ["Coordinates","Faces"]
       },
       "IfcAxis2Placement3D": {
          "type": "IfcAxis2Placement3D",


### PR DESCRIPTION
* IfcTriangulatedFaceSet
* IfcPolygonalFaceSet
* IfcIndexedPolyCurve (e.g. used as extrusion profile)

May be related to #890 and solve it partially. These are only some common entity types for geometric representations introduced in IFC4. There are few more and I'd be happy to add them, but I am not sure how exhaustive the query ifc4stdlib is meant to be in terms of geometric representations.