### PR TITLE
squeeze https requests through proxy if need be

### DIFF
--- a/BimServerJar/src/org/bimserver/starter/Starter.java
+++ b/BimServerJar/src/org/bimserver/starter/Starter.java
@@ -442,6 +442,8 @@ public class Starter extends JFrame {
 			if (useProxy.isSelected()) {
 				commands.add("-Dhttp.proxyHost=" + proxyHost.getText());
 				commands.add("-Dhttp.proxyPort=" + proxyPort.getText());
+				commands.add("-Dhttps.proxyHost=" + proxyHost.getText());
+				commands.add("-Dhttps.proxyPort=" + proxyPort.getText());
 			}
 			
 			String cp = "." + File.pathSeparator;

--- a/PluginBase/src/org/bimserver/plugins/MavenPluginLocation.java
+++ b/PluginBase/src/org/bimserver/plugins/MavenPluginLocation.java
@@ -72,7 +72,7 @@ public class MavenPluginLocation extends PluginLocation<MavenPluginVersion> {
 
 	protected MavenPluginLocation(MavenPluginRepository mavenPluginRepository, String defaultrepository, String groupId, String artifactId) {
 		this.mavenPluginRepository = mavenPluginRepository;
-		this.mavenPluginRepository.addRepository(new RemoteRepository.Builder("given", "default", defaultrepository).build());
+		this.mavenPluginRepository.addRepository("given", "default", defaultrepository);
 		this.defaultrepository = defaultrepository;
 		this.groupId = groupId;
 		this.artifactId = artifactId;

--- a/PluginBase/src/org/bimserver/plugins/MavenPluginRepository.java
+++ b/PluginBase/src/org/bimserver/plugins/MavenPluginRepository.java
@@ -31,14 +31,12 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.repository.*;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.jetbrains.idea.maven.aether.JreProxySelector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +46,7 @@ public class MavenPluginRepository {
 	private final RepositorySystemSession session;
 	private final Set<RemoteRepository> repositories = new LinkedHashSet<>();
 	private final List<RemoteRepository> localRepositories;
+	private final JreProxySelector proxySelector = new JreProxySelector();
 	private String defaultRemoteRepositoryLocation;
 	private Path localRepoFile;
 	private RemoteRepository local;
@@ -63,15 +62,15 @@ public class MavenPluginRepository {
 		system = newRepositorySystem();
 		session = newRepositorySystemSession(system, localRepoFile);
 
+		Proxy proxy = proxySelector.getProxy(defaultLocalRepositoryLocation);
+
 		RemoteRepository.Builder builder = new RemoteRepository.Builder("central", "default", defaultRemoteRepositoryLocation);
 		builder.setPolicy(new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_INTERVAL + ":60", RepositoryPolicy.CHECKSUM_POLICY_FAIL));
-		RemoteRepository remoteRepository = builder.build();
-
-		repositories.add(remoteRepository);
+		repositories.add(builder.setProxy(proxy).build());
 
 		builder = new RemoteRepository.Builder("public", "default", "http://public.logic-labs.nl.s3.amazonaws.com/release");
 		builder.setPolicy(new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_INTERVAL + ":60", RepositoryPolicy.CHECKSUM_POLICY_IGNORE));
-		repositories.add(builder.build());
+		repositories.add(builder.setProxy(proxy).build());
 
 		if (defaultLocalRepositoryLocation != null) {
 			RemoteRepository.Builder localRepoBuilder = new RemoteRepository.Builder("local", "default", "file://" + defaultLocalRepositoryLocation);
@@ -115,6 +114,7 @@ public class MavenPluginRepository {
 
 	private DefaultRepositorySystemSession newRepositorySystemSession(RepositorySystem system, Path localRepoFile) {
 		DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+		session.setProxySelector(proxySelector);
 
 		LocalRepository localRepo = new LocalRepository(localRepoFile.toFile());
 		LocalRepositoryManager manager = system.newLocalRepositoryManager(session, localRepo);
@@ -147,7 +147,9 @@ public class MavenPluginRepository {
 		return localRepositories;
 	}
 
-	public void addRepository(RemoteRepository repository) {
-		repositories.add(repository);
+	public void addRepository(String id, String type, String url){
+		repositories.add(
+			new RemoteRepository.Builder(id, type, url).setProxy(proxySelector.getProxy(url)).build()
+		);
 	}
 }

--- a/PluginBase/src/org/jetbrains/idea/maven/aether/JreProxySelector.java
+++ b/PluginBase/src/org/jetbrains/idea/maven/aether/JreProxySelector.java
@@ -1,0 +1,134 @@
+// Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.idea.maven.aether;
+
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.*;
+
+import java.net.*;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * This is a modified copy of the corresponding Aether class that adds support for https proxy types
+ */
+public class JreProxySelector implements ProxySelector {
+
+  public JreProxySelector() {
+  }
+
+  @Override
+  public Proxy getProxy(RemoteRepository repository) {
+    return getProxy(repository.getUrl());
+  }
+
+  public Proxy getProxy(final String url) {
+    try {
+      final java.net.ProxySelector systemSelector = java.net.ProxySelector.getDefault();
+      if (systemSelector == null) {
+        return null;
+      }
+      final URI uri = new URI(url).parseServerAuthority();
+      final List<java.net.Proxy> selected = systemSelector.select(uri);
+      if (selected == null || selected.isEmpty()) {
+        return null;
+      }
+      for (java.net.Proxy proxy : selected) {
+        if (proxy.type() == java.net.Proxy.Type.HTTP && isValid(proxy.address())) {
+          final String proxyType = chooseProxyType(uri.getScheme());
+          if (proxyType != null) {
+            final InetSocketAddress addr = (InetSocketAddress)proxy.address();
+            return new Proxy(proxyType, addr.getHostName(), addr.getPort(), JreProxyAuthentication.INSTANCE);
+          }
+        }
+      }
+    }
+    catch (Throwable e) {
+      // URL invalid or not accepted by selector or no selector at all, simply use no proxy
+    }
+    return null;
+  }
+
+  private static String chooseProxyType(final String protocol) {
+    if (Proxy.TYPE_HTTP.equals(protocol)) {
+      return Proxy.TYPE_HTTP;
+    }
+    if (Proxy.TYPE_HTTPS.equals(protocol)) {
+      return Proxy.TYPE_HTTPS;
+    }
+    return null;
+  }
+
+  private static boolean isValid(SocketAddress address) {
+    if (address instanceof InetSocketAddress) {
+      /*
+       * NOTE: On some platforms with java.net.useSystemProxies=true, unconfigured proxies show up as proxy
+       * objects with empty host and port 0.
+       */
+      final InetSocketAddress addr = (InetSocketAddress)address;
+      return addr.getPort() > 0 && addr.getHostName() != null && !addr.getHostName().isEmpty();
+    }
+    return false;
+  }
+
+  private static final class JreProxyAuthentication implements Authentication {
+
+    public static final Authentication INSTANCE = new JreProxyAuthentication();
+
+    @Override
+    public void fill(AuthenticationContext context, String key, Map<String, String> data) {
+      Proxy proxy = context.getProxy();
+      if (proxy == null) {
+        return;
+      }
+      if (!AuthenticationContext.USERNAME.equals(key) && !AuthenticationContext.PASSWORD.equals(key)) {
+        return;
+      }
+
+      try {
+        URL url;
+        String protocol = "http";
+        try {
+          url = new URL(context.getRepository().getUrl());
+          protocol = url.getProtocol();
+        }
+        catch (Exception e) {
+          url = null;
+        }
+
+        PasswordAuthentication auth = Authenticator.requestPasswordAuthentication(
+          proxy.getHost(), null, proxy.getPort(), protocol, "Credentials for proxy " + proxy, null, url, Authenticator.RequestorType.PROXY
+        );
+        if (auth != null) {
+          context.put(AuthenticationContext.USERNAME, auth.getUserName());
+          context.put(AuthenticationContext.PASSWORD, auth.getPassword());
+        }
+        else {
+          context.put(AuthenticationContext.USERNAME, System.getProperty(protocol + ".proxyUser"));
+          context.put(AuthenticationContext.PASSWORD, System.getProperty(protocol + ".proxyPassword"));
+        }
+      }
+      catch (SecurityException e) {
+        // oh well, let's hope the proxy can do without auth
+      }
+    }
+
+    @Override
+    public void digest(AuthenticationDigest digest) {
+      // we don't know anything about the JRE's current authenticator, assume the worst (i.e. interactive)
+      digest.update(UUID.randomUUID().toString());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj || (obj != null && getClass().equals(obj.getClass()));
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
+  }
+}
+

--- a/Shared/src/org/bimserver/plugins/PluginBundleManager.java
+++ b/Shared/src/org/bimserver/plugins/PluginBundleManager.java
@@ -152,8 +152,7 @@ public class PluginBundleManager implements AutoCloseable {
 			throws DependencyCollectionException, InvalidVersionSpecificationException, Exception {
 		if (model.getRepositories() != null) {
 			for (Repository repository : model.getRepositories()) {
-				RemoteRepository remoteRepository = new RemoteRepository.Builder(repository.getId(), "default", repository.getUrl()).build();
-				mavenPluginRepository.addRepository(remoteRepository);
+				mavenPluginRepository.addRepository(repository.getId(), "default", repository.getUrl());
 			}
 		}
 


### PR DESCRIPTION
These maven related changes have the effect that JVM system properties `https.proxyHost` and `https.proxyPort` are used when set. This way plugins and dependencies specified with https URLs can be installed from behind a proxy. To set the system properties from the starter GUI, the same values as `http.proxyHost` and `http.proxyPort` are used.