### PR TITLE
JsonQueryObjectModelConverter: added guids filter

### DIFF
--- a/PluginBase/src/org/bimserver/database/queries/om/JsonQueryObjectModelConverter.java
+++ b/PluginBase/src/org/bimserver/database/queries/om/JsonQueryObjectModelConverter.java
@@ -101,6 +101,13 @@ public class JsonQueryObjectModelConverter {
 					oidsNode.add(oid);
 				}
 			}
+			if (queryPart.hasGuids()) {
+				ArrayNode guidsNode = OBJECT_MAPPER.createArrayNode();
+				queryPartNode.set("guids", guidsNode);
+				for (String guid : queryPart.getGuids()) {
+					guidsNode.add(guid);
+				}
+			}
 			if (queryPart.hasInBoundingBox()) {
 				ObjectNode inBoundingBoxNode = OBJECT_MAPPER.createObjectNode();
 				if (!Double.isNaN(queryPart.getInBoundingBox().getX())) {


### PR DESCRIPTION
- Fixed QueryPart's GUID filter being ignored https://github.com/opensourceBIM/BIMserver/issues/1255

Note: I used Github's in-line edit. It reported that the line endings were inconsistent and converted them. That is why the diff looks so large. I hope this is not an issue.