### PR TITLE
Fix potential FileSystemException for too long filenames

### DIFF
--- a/BimServer/src/org/bimserver/webservices/impl/ServiceImpl.java
+++ b/BimServer/src/org/bimserver/webservices/impl/ServiceImpl.java
@@ -1289,11 +1289,16 @@ public class ServiceImpl extends GenericServiceImpl implements ServiceInterface 
 		if (fileName.contains("\\")) {
 			fileName = fileName.substring(fileName.lastIndexOf("\\") + 1);
 		}
-
-		// Replace anything that isn't a valid word (alphanumeric), underscore, or period symbol. 
-		// This avoids FileSystemExceptions for invalid filenames
-		fileName = fileName.replaceAll("[^\\w_\\.]+", "");
 		
+		// NTFS doesn't allow filenames to be longer than 255 characters. Windows technically 
+		// allows up to 260 characters, minus one to keep space for null terminators (so 259 
+		// characters). However to be save we follow NTFS limits, and apply the same terminator
+		// rule (255-1). See: https://stackoverflow.com/a/265782/4497744
+		final int maxNtfsFileNameLength = 254;
+		if (fileName.length() >= maxNtfsFileNameLength) {
+			fileName = fileName.substring(0, maxNtfsFileNameLength);
+		}
+
 		Path file = userDirIncoming.resolve(fileName);
 		return file;
 	}

--- a/BimServer/src/org/bimserver/webservices/impl/ServiceImpl.java
+++ b/BimServer/src/org/bimserver/webservices/impl/ServiceImpl.java
@@ -1290,6 +1290,10 @@ public class ServiceImpl extends GenericServiceImpl implements ServiceInterface 
 			fileName = fileName.substring(fileName.lastIndexOf("\\") + 1);
 		}
 
+		// Replace anything that isn't a valid word (alphanumeric), underscore, or period symbol. 
+		// This avoids FileSystemExceptions for invalid filenames
+		fileName = fileName.replaceAll("[^\\w_\\.]+", "");
+		
 		Path file = userDirIncoming.resolve(fileName);
 		return file;
 	}


### PR DESCRIPTION
When checking in files from remote URLs with complex URL parts there is a risk of a FileSystemException as the filename may be invalid for the filesystem. An example of such a URL part is `Mw6G5s+9ZWTshlSdu4jWr9wAZ7DVFOlF7UMJoC4JUg8+4vDpfUN6pXXQnLQ2eW3O9J+y9fzCT2UuJ0ZzZZ77ezF8ZGMAZNfGCDC7%2FEYjMs0UWlzBjBtyemZdsvoRSMofc24NeU0l2va63jtB+yLHDRJyihD%2FLZ4Oa5zSJFCmy+jTLJWvvIIPJWWfPU725axiVt%2FFUGK3FyreYyQDao4l5VDdwb0t8bNsPfE1YPwTMI00wX2WPF2K2V63W0Q%2FT03cC4qkPLLCdCxVZPbWK3gc2MbDHdXZLlwAHr0eMWGo89syWFCBxLqyFv0wPZ%2Fu9Uo8`, which yields:
```java
java.nio.file.FileSystemException: D:\Projects\BIMserver\home\incoming\username\filename: The filename, directory name, or volume label syntax is incorrect.
	at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
	at java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:235)
	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:478)
	at java.base/java.nio.file.Files.newOutputStream(Files.java:219)
	at org.bimserver.webservices.impl.RestartableInputStream.<init>(RestartableInputStream.java:43)
	at org.bimserver.webservices.impl.ServiceImpl.checkinInternal(ServiceImpl.java:1212)
	at org.bimserver.webservices.impl.ServiceImpl.checkinInitiatedInternal(ServiceImpl.java:1094)
	at org.bimserver.webservices.impl.ServiceImpl.checkinInitiatedSync(ServiceImpl.java:1165)

```

The proposed changes replace all characters that are not alphanumeric or a underscore or period symbol. So e.g. the above turns into: `Mw6G5s9ZWTshlSdu4jWr9wAZ7DVFOlF7UMJoC4JUg84vDpfUN6pXXQnLQ2eW3O9Jy9fzCT2UuJ0ZzZZ77ezF8ZGMAZNfGCDC72FEYjMs0UWlzBjBtyemZdsvoRSMofc24NeU0l2va63jtByLHDRJyihD2FLZ4Oa5zSJFCmyjTLJWvvIIPJWWfPU725axiVt2FFUGK3FyreYyQDao4l5VDdwb0t8bNsPfE1YPwTMI00wX2WPF2K2V63W0Q2FT03cC4qkPLLCdCxVZPbWK3gc2MbDHdXZLlwAHr0eMWGo89syWFCBxLqyFv0wPZ2Fu9Uo8`, which is a valid filename 
