### PR TITLE
fix #1237 Use ensureCapacity in ByteBufferVirtualObject

### DIFF
--- a/Shared/src/org/bimserver/shared/ByteBufferVirtualObject.java
+++ b/Shared/src/org/bimserver/shared/ByteBufferVirtualObject.java
@@ -50,14 +50,13 @@ public class ByteBufferVirtualObject extends AbstractByteBufferVirtualObject imp
 	private Map<Integer, ByteBufferList> referencedBuffers;
 	
 	public ByteBufferVirtualObject(QueryContext reusable, EClass eClass, int capacity) {
-		super(Math.max(capacity, 17)); // 17 bytes are always needed
+		super(Math.max(capacity, reusable.getPackageMetaData().getUnsettedLength(eClass) + 16)); // 16 bytes plus the class specific ones are always needed
 		this.reusable = reusable;
 		this.eClass = eClass;
 		this.oid = reusable.getDatabaseInterface().newOid(eClass);
 		this.uuid = reusable.getDatabaseInterface().newUuid();
 
 		int unsettedLength = reusable.getPackageMetaData().getUnsettedLength(eClass);
-		ensureCapacity(buffer.position(), 16 + unsettedLength);
 		buffer.put(new byte[unsettedLength]);
 		buffer.putLong(this.uuid.getMostSignificantBits());
 		buffer.putLong(this.uuid.getLeastSignificantBits());

--- a/Shared/src/org/bimserver/shared/ByteBufferVirtualObject.java
+++ b/Shared/src/org/bimserver/shared/ByteBufferVirtualObject.java
@@ -57,6 +57,7 @@ public class ByteBufferVirtualObject extends AbstractByteBufferVirtualObject imp
 		this.uuid = reusable.getDatabaseInterface().newUuid();
 
 		int unsettedLength = reusable.getPackageMetaData().getUnsettedLength(eClass);
+		ensureCapacity(buffer.position(), 16 + unsettedLength);
 		buffer.put(new byte[unsettedLength]);
 		buffer.putLong(this.uuid.getMostSignificantBits());
 		buffer.putLong(this.uuid.getLeastSignificantBits());


### PR DESCRIPTION
I added a missing call to ensureCapacity in the constructor. Now a bigger buffer should be created, if too small.

(Now that I think about it, one could also just calculate the right size in the super constructor and skip the reallocation)