### PR TITLE
Update dependencies in Test module

### DIFF
--- a/BimServerClientLib/pom.xml
+++ b/BimServerClientLib/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.15</version>
+			<version>${logback.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/BimServerJar/pom.xml
+++ b/BimServerJar/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.15</version>
+			<version>${logback.version}</version>
 		</dependency>
 	</dependencies>
 	<licenses>

--- a/BimServerWar/pom.xml
+++ b/BimServerWar/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.15</version>
+			<version>${logback.version}</version>
 		</dependency>
 	</dependencies>
 	<licenses>

--- a/Tests/pom.xml
+++ b/Tests/pom.xml
@@ -38,7 +38,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>${logback.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opensourcebim</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jetty.version>9.4.57.v20241219</jetty.version>
 		<cxf.version>3.5.10</cxf.version>
+		<logback.version>1.3.15</logback.version>
 	</properties>
 	<scm>
 		<url>https://github.com/opensourceBIM/BIMserver.git</url>


### PR DESCRIPTION
issue: Failed to load class org.slf4j.impl.StaticLoggerBinder

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
```

Added logback-classic. For logback version >1.3 will target slf4j-api 2.x   

https://www.slf4j.org/codes.html#StaticLoggerBinder   
https://www.slf4j.org/faq.html#changesInVersion200ww.slf4j.org/faq.html#changesInVersion200