### PR TITLE
fix #1356 color hash for geometry reuse is always 1

### DIFF
--- a/BimServer/src/org/bimserver/geometry/StreamingGeometryGenerator.java
+++ b/BimServer/src/org/bimserver/geometry/StreamingGeometryGenerator.java
@@ -1147,8 +1147,12 @@ public class StreamingGeometryGenerator extends GenericGeometryGenerator {
 		return size;
 	}
 
-	// TODO add color??
 	int hash(ByteBuffer indices, ByteBuffer vertices, ByteBuffer normals, ByteBuffer colors) {
+		indices.position(0);
+		vertices.position(0);
+		normals.position(0);
+		colors.position(0);
+		
 		int hashCode = 0;
 		hashCode += indices.hashCode();
 		hashCode += vertices.hashCode();


### PR DESCRIPTION
This commit is resetting positions on all ByteBuffers to make sure the whole buffer is hashed.