### PR TITLE
Fix for Issue #1359

### DIFF
--- a/BimServer/src/org/bimserver/serializers/SerializerFactory.java
+++ b/BimServer/src/org/bimserver/serializers/SerializerFactory.java
@@ -115,6 +115,7 @@ public class SerializerFactory {
 							ProjectInfo projectInfo = new ProjectInfo();
 							projectInfo.setName(project.getName());
 							projectInfo.setDescription(project.getDescription());
+							projectInfo.setMultiplierToMm(project.getExportLengthMeasurePrefix());
 							GeoTag geoTag = project.getGeoTag();
 							if (geoTag != null && geoTag.getEnabled()) {
 								projectInfo.setX(geoTag.getX());

--- a/BimServer/src/org/bimserver/serializers/SerializerFactory.java
+++ b/BimServer/src/org/bimserver/serializers/SerializerFactory.java
@@ -34,11 +34,7 @@ import org.bimserver.ifc.BasicIfcModel;
 import org.bimserver.ifc.IfcModel;
 import org.bimserver.interfaces.objects.SPluginDescriptor;
 import org.bimserver.longaction.DownloadParameters;
-import org.bimserver.models.store.GeoTag;
-import org.bimserver.models.store.MessagingSerializerPluginConfiguration;
-import org.bimserver.models.store.Project;
-import org.bimserver.models.store.SerializerPluginConfiguration;
-import org.bimserver.models.store.StorePackage;
+import org.bimserver.models.store.*;
 import org.bimserver.plugins.PluginConfiguration;
 import org.bimserver.plugins.PluginManager;
 import org.bimserver.plugins.renderengine.RenderEnginePlugin;
@@ -115,7 +111,10 @@ public class SerializerFactory {
 							ProjectInfo projectInfo = new ProjectInfo();
 							projectInfo.setName(project.getName());
 							projectInfo.setDescription(project.getDescription());
-							projectInfo.setMultiplierToMm(project.getExportLengthMeasurePrefix());
+
+							ConcreteRevision lastConcreteRevision = project.getLastConcreteRevision();
+							projectInfo.setMultiplierToMm(lastConcreteRevision.getMultiplierToMm());
+
 							GeoTag geoTag = project.getGeoTag();
 							if (geoTag != null && geoTag.getEnabled()) {
 								projectInfo.setX(geoTag.getX());

--- a/PluginBase/src/org/bimserver/plugins/serializers/ProjectInfo.java
+++ b/PluginBase/src/org/bimserver/plugins/serializers/ProjectInfo.java
@@ -37,7 +37,6 @@ import org.bimserver.interfaces.objects.SBounds;
  *****************************************************************************/
 
 import org.bimserver.interfaces.objects.SVector3f;
-import org.bimserver.models.store.SIPrefix;
 
 public class ProjectInfo {
 	private String name;
@@ -137,9 +136,5 @@ public class ProjectInfo {
 	
 	public void setMultiplierToMm(float multiplierToMm) {
 		this.multiplierToMm = multiplierToMm;
-	}
-
-	public void setMultiplierToMm(SIPrefix unit) {
-		this.multiplierToMm = (float) Math.pow(10, unit.getValue()+3);
 	}
 }

--- a/PluginBase/src/org/bimserver/plugins/serializers/ProjectInfo.java
+++ b/PluginBase/src/org/bimserver/plugins/serializers/ProjectInfo.java
@@ -37,6 +37,7 @@ import org.bimserver.interfaces.objects.SBounds;
  *****************************************************************************/
 
 import org.bimserver.interfaces.objects.SVector3f;
+import org.bimserver.models.store.SIPrefix;
 
 public class ProjectInfo {
 	private String name;
@@ -136,5 +137,9 @@ public class ProjectInfo {
 	
 	public void setMultiplierToMm(float multiplierToMm) {
 		this.multiplierToMm = multiplierToMm;
+	}
+
+	public void setMultiplierToMm(SIPrefix unit) {
+		this.multiplierToMm = (float) Math.pow(10, unit.getValue()+3);
 	}
 }


### PR DESCRIPTION
In this, I add two lines to SerializerFactory.java which take the last concrete revision for the given project and sets the ProjectInfo.multiplierToMm to the given unit.  This is intended to work together with a change to the GLTFSerializers Plugin which allows for the scaling of a .glb/.gltf model depending on the units of the project file.