### PR TITLE
Issue #1353 null call get project by UUID

### DIFF
--- a/BimServer/src/org/bimserver/database/DatabaseSession.java
+++ b/BimServer/src/org/bimserver/database/DatabaseSession.java
@@ -1644,6 +1644,30 @@ public class DatabaseSession implements LazyLoader, OidProvider, DatabaseInterfa
 		return map;
 	}
 
+	public <T extends IdEObject> Map<UUID, T> queryUuid(Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
+		IfcModelInterface model = createModel(query);
+		return queryUuid(model, condition, clazz, query);
+	}
+	public <T extends IdEObject> Map<UUID, T> queryUuid(IfcModelInterface model, Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
+		Map<UUID, T> map = new HashMap<UUID, T>();
+		Set<EClass> eClasses = new HashSet<EClass>();
+		condition.getEClassRequirements(eClasses);
+		for (EClass eClass : eClasses) {
+			TodoList todoList = new TodoList();
+			getMap(eClass, model, query, todoList);
+			processTodoList(model, todoList, query);
+			List<IdEObject> list = new ArrayList<IdEObject>(model.getValues());
+			for (IdEObject object : list) {
+				if (clazz.isInstance(object)) {
+					if (condition.matches(object)) {
+						map.put(object.getUuid(), clazz.cast(object));
+					}
+				}
+			}
+		}
+		return map;
+	}
+
 	public <T extends IdEObject> T querySingle(Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
 		checkOpen();
 		Collection<T> values = query(condition, clazz, query).values();


### PR DESCRIPTION
This commit is aimed towards fixing Issue #1353.  In it, two files are changed, DatabaseSession.java and GetProjectByUuidDatabaseAction.java.  The former introduces a new queryUuid() method which follows the previous query() method; however, it maps the IdEObject value to a uuid key (this is aimed to improve the O time complexity by allowing for the use of .contains within a hashmap in GetProjectByUuidDatabaseAction.execute()).  Furthermore, if wanted, this function can also be used for other objects if one needs to query for a uuid mapping.  In the latter, logic is added to call this new queryUuid() method, perform authentication checks, make a uuid comparison to find a potential match, and throwan exception if something goes wrong (i.e. authentication, project not found, or invalid input).