### PR TITLE
Issue #1353, fixed NullCall in GetProjectByUuidDatabaseAction.java

### DIFF
--- a/BimServer/src/org/bimserver/database/DatabaseSession.java
+++ b/BimServer/src/org/bimserver/database/DatabaseSession.java
@@ -1644,6 +1644,30 @@ public class DatabaseSession implements LazyLoader, OidProvider, DatabaseInterfa
 		return map;
 	}
 
+	public <T extends IdEObject> Map<UUID, T> queryUuid(Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
+		IfcModelInterface model = createModel(query);
+		return queryUuid(model, condition, clazz, query);
+	}
+	public <T extends IdEObject> Map<UUID, T> queryUuid(IfcModelInterface model, Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
+		Map<UUID, T> map = new HashMap<UUID, T>();
+		Set<EClass> eClasses = new HashSet<EClass>();
+		condition.getEClassRequirements(eClasses);
+		for (EClass eClass : eClasses) {
+			TodoList todoList = new TodoList();
+			getMap(eClass, model, query, todoList);
+			processTodoList(model, todoList, query);
+			List<IdEObject> list = new ArrayList<IdEObject>(model.getValues());
+			for (IdEObject object : list) {
+				if (clazz.isInstance(object)) {
+					if (condition.matches(object)) {
+						map.put(object.getUuid(), clazz.cast(object));
+					}
+				}
+			}
+		}
+		return map;
+	}
+
 	public <T extends IdEObject> T querySingle(Condition condition, Class<T> clazz, QueryInterface query) throws BimserverDatabaseException {
 		checkOpen();
 		Collection<T> values = query(condition, clazz, query).values();

--- a/BimServer/src/org/bimserver/database/actions/GetProjectByUuidDatabaseAction.java
+++ b/BimServer/src/org/bimserver/database/actions/GetProjectByUuidDatabaseAction.java
@@ -19,11 +19,22 @@ package org.bimserver.database.actions;
 
 import org.bimserver.BimserverDatabaseException;
 import org.bimserver.database.BimserverLockConflictException;
+import org.bimserver.database.Database;
 import org.bimserver.database.DatabaseSession;
+import org.bimserver.database.OldQuery;
+import org.bimserver.database.query.conditions.AttributeCondition;
+import org.bimserver.database.query.conditions.Condition;
+import org.bimserver.database.query.conditions.IsOfTypeCondition;
+import org.bimserver.database.query.conditions.Not;
+import org.bimserver.database.query.literals.StringLiteral;
 import org.bimserver.models.log.AccessMethod;
-import org.bimserver.models.store.Project;
+import org.bimserver.models.store.*;
 import org.bimserver.shared.exceptions.UserException;
 import org.bimserver.webservices.authorization.Authorization;
+
+import java.util.Map;
+import java.util.UUID;
+
 public class GetProjectByUuidDatabaseAction extends BimDatabaseAction<Project> {
 
 	private final String uuid;
@@ -37,24 +48,30 @@ public class GetProjectByUuidDatabaseAction extends BimDatabaseAction<Project> {
 
 	@Override
 	public Project execute() throws UserException, BimserverLockConflictException, BimserverDatabaseException {
-//		List<IdEObject> projects = (List<IdEObject>) getDatabaseSession().query(StorePackage.eINSTANCE.getProject_Uuid(), uuid);
-//		if (projects.size() == 0) {
-//			throw new UserException("Project with uuid " + uuid + " does not exist");
-//		}
-//		Project project = (Project) projects.get(0);
-//		User user = getUserByUoid(authorization.getUoid());
-//		if (user == null) {
-//			throw new UserException("Authenticated user required");
-//		}
-//		if (project.getState() == ObjectState.DELETED && user.getUserType() != UserType.ADMIN) {
-//			throw new UserException("Project has been deleted");
-//		}
-//		if (authorization.hasRightsOnProjectOrSuperProjectsOrSubProjects(user, project)) {
-//			return project;
-//		} else {
-//			throw new UserException("User '" + user.getUsername() + "' has no rights on this project");
-//		}
-		// TODO reimplement
-		return null;
+
+		UUID comparisonUUID;
+		try {
+			comparisonUUID = UUID.fromString(uuid);
+		}
+		catch (IllegalArgumentException e) {
+			throw new UserException("Invalid uuid format");
+		}
+		User user = getUserByUoid(authorization.getUoid());
+		Not notStoreProject = new Not(new AttributeCondition(StorePackage.eINSTANCE.getProject_Name(), new StringLiteral(Database.STORE_PROJECT_NAME)));
+		Condition condition = new IsOfTypeCondition(StorePackage.eINSTANCE.getProject()).and(notStoreProject);
+		Map<UUID, Project> results = getDatabaseSession().queryUuid(condition, Project.class, OldQuery.getDefault());
+		if (results.containsKey(comparisonUUID)) {
+			if (!authorization.hasRightsOnProject(user, results.get(comparisonUUID))) {
+				throw new UserException("You do not have rights on this project");
+			}
+			if (!results.get(comparisonUUID).getState().equals(ObjectState.ACTIVE) &&
+					user.getUserType() != UserType.ADMIN && user.getUserType() != UserType.SYSTEM){
+				throw new UserException("This project is not active");
+			}
+			return results.get(comparisonUUID);
+		}
+		else {
+			throw new UserException("Project with uuid " + uuid + " does not exist");
+		}
 	}
 }


### PR DESCRIPTION
This commit is aimed towards fixing Issue #1353. In it, two files are changed, DatabaseSession.java and GetProjectByUuidDatabaseAction.java. The former introduces a new queryUuid() method which follows the previous query() method; however, it maps the IdEObject value to a uuid key (this is aimed to improve the O time complexity by allowing for the use of .contains within a hashmap in GetProjectByUuidDatabaseAction.execute()). Furthermore, if wanted, this function can also be used for other objects if one needs to query for a uuid mapping. In the latter, logic is added to call this new queryUuid() method, perform authentication checks, make a uuid comparison to find a potential match, and throw an exception if something goes wrong (i.e. authentication, project not found, or invalid input).